### PR TITLE
Feature/custom config flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,7 @@ var (
 	}
 
 	createTicket bool
+	configFile   string
 
 	rootCmd = &cobra.Command{
 		Use:     "supabase",
@@ -234,6 +235,7 @@ func init() {
 	flags.Var(&utils.OutputFormat, "output", "output format of status variables")
 	flags.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
 	flags.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
+	flags.StringVar(&configFile, "config-file", "", "path to config file (default: supabase/config.toml)")
 	cobra.CheckErr(viper.BindPFlags(flags))
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
+	flagsutils "github.com/supabase/cli/internal/utils/flags"
 	"golang.org/x/mod/semver"
 )
 
@@ -104,12 +104,12 @@ var (
 				}
 				ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 				if cmd.Flags().Lookup("project-ref") != nil {
-					if err := flags.ParseProjectRef(ctx, fsys); err != nil {
+					if err := flagsutils.ParseProjectRef(ctx, fsys); err != nil {
 						return err
 					}
 				}
 			}
-			if err := flags.ParseDatabaseConfig(cmd.Flags(), fsys); err != nil {
+			if err := flagsutils.ParseDatabaseConfig(cmd.Flags(), fsys); err != nil {
 				return err
 			}
 			// Prepare context
@@ -226,16 +226,16 @@ func init() {
 		viper.AutomaticEnv()
 	})
 
-	f := rootCmd.PersistentFlags()
-	f.Bool("debug", false, "output debug logs to stderr")
-	f.String("workdir", "", "path to a Supabase project directory")
-	f.Bool("experimental", false, "enable experimental features")
-	f.String("network-id", "", "use the specified docker network instead of a generated one")
-	f.StringVar(&flags.ConfigFile, "config-file", "", "path to config file (default: supabase/config.toml)")
-	f.Var(&utils.OutputFormat, "output", "output format of status variables")
-	f.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
-	f.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
-	cobra.CheckErr(viper.BindPFlags(f))
+	flags := rootCmd.PersistentFlags()
+	flags.Bool("debug", false, "output debug logs to stderr")
+	flags.String("workdir", "", "path to a Supabase project directory")
+	flags.Bool("experimental", false, "enable experimental features")
+	flags.String("network-id", "", "use the specified docker network instead of a generated one")
+	flags.StringVar(&flagsutils.ConfigFile, "config-file", "", "path to config file (default: supabase/config.toml)")
+	flags.Var(&utils.OutputFormat, "output", "output format of status variables")
+	flags.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
+	flags.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
+	cobra.CheckErr(viper.BindPFlags(flags))
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddGroup(&cobra.Group{ID: groupQuickStart, Title: "Quick Start:"})
@@ -264,6 +264,6 @@ func addSentryScope(scope *sentry.Scope) {
 	scope.SetContext("Services", imageToVersion)
 	scope.SetContext("Config", map[string]interface{}{
 		"Image Registry": utils.GetRegistry(),
-		"Project ID":     flags.ProjectRef,
+		"Project ID":     flagsutils.ProjectRef,
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,6 @@ var (
 	}
 
 	createTicket bool
-	configFile   string
 
 	rootCmd = &cobra.Command{
 		Use:     "supabase",
@@ -227,16 +226,16 @@ func init() {
 		viper.AutomaticEnv()
 	})
 
-	flags := rootCmd.PersistentFlags()
-	flags.Bool("debug", false, "output debug logs to stderr")
-	flags.String("workdir", "", "path to a Supabase project directory")
-	flags.Bool("experimental", false, "enable experimental features")
-	flags.String("network-id", "", "use the specified docker network instead of a generated one")
-	flags.Var(&utils.OutputFormat, "output", "output format of status variables")
-	flags.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
-	flags.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
-	flags.StringVar(&configFile, "config-file", "", "path to config file (default: supabase/config.toml)")
-	cobra.CheckErr(viper.BindPFlags(flags))
+	f := rootCmd.PersistentFlags()
+	f.Bool("debug", false, "output debug logs to stderr")
+	f.String("workdir", "", "path to a Supabase project directory")
+	f.Bool("experimental", false, "enable experimental features")
+	f.String("network-id", "", "use the specified docker network instead of a generated one")
+	f.StringVar(&flags.ConfigFile, "config-file", "", "path to config file (default: supabase/config.toml)")
+	f.Var(&utils.OutputFormat, "output", "output format of status variables")
+	f.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
+	f.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
+	cobra.CheckErr(viper.BindPFlags(f))
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddGroup(&cobra.Group{ID: groupQuickStart, Title: "Quick Start:"})

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -118,34 +118,34 @@ func TestStartCommand(t *testing.T) {
 		
 		// Write config file
 		require.NoError(t, afero.WriteFile(fsys, customPath, []byte(`# Test configuration
-project_id = "`+projectId+`"
+		project_id = "`+projectId+`"
 
-[api]
-enabled = true
-port = 54331
-schemas = ["public", "storage", "graphql_public"]
-extra_search_path = ["public", "extensions"]
-max_rows = 1000
+		[api]
+		enabled = true
+		port = 54331
+		schemas = ["public", "storage", "graphql_public"]
+		extra_search_path = ["public", "extensions"]
+		max_rows = 1000
 
-[db]
-port = 54332
-shadow_port = 54330
-major_version = 15
+		[db]
+		port = 54332
+		shadow_port = 54330
+		major_version = 15
 
-[studio]
-port = 54333
+		[studio]
+		port = 54333
 
-[inbucket]
-port = 54334
+		[inbucket]
+		port = 54334
 
-[storage]
-file_size_limit = "50MiB"
+		[storage]
+		file_size_limit = "50MiB"
 
-[auth]
-site_url = "http://localhost:54331"
-additional_redirect_urls = ["http://localhost:54331"]
-jwt_expiry = 3600
-enable_signup = true`), 0644))
+		[auth]
+		site_url = "http://localhost:54331"
+		additional_redirect_urls = ["http://localhost:54331"]
+		jwt_expiry = 3600
+		enable_signup = true`), 0644))
 		
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))

--- a/internal/utils/flags/config_path.go
+++ b/internal/utils/flags/config_path.go
@@ -9,9 +9,17 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
+var ConfigFile string
+
 func LoadConfig(fsys afero.Fs) error {
 	utils.Config.ProjectId = ProjectRef
-	if err := utils.Config.Load("", utils.NewRootFS(fsys)); err != nil {
+	
+	configPath := ""
+	if ConfigFile != "" {
+		configPath = ConfigFile
+	}
+	
+	if err := utils.Config.Load(configPath, utils.NewRootFS(fsys)); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			utils.CmdSuggestion = fmt.Sprintf("Have you set up the project with %s?", utils.Aqua("supabase init"))
 		}


### PR DESCRIPTION
# Add Custom Config File Support

Introduces a new `--config-file` flag to the Supabase CLI, enabling users to specify alternative configuration files. This enhancement allows running multiple parallel local development environments with different configurations (https://github.com/supabase/cli/issues/2139).

## Example Usage

```bash
supabase start --config-file=supabase/config.test.toml
```

## Benefits
- Supports multiple local database instances with different configurations
- Simplifies management of different environment setups (e.g., testing, staging)
- Maintains backwards compatibility with default config path

